### PR TITLE
Blatt 3 Aufgabe 2 improved subtask c) and d) (and g))

### DIFF
--- a/project/src/main/java/de/unistuttgart/informatik/fius/jvk/verifier/Sheet3Task2Verifier.java
+++ b/project/src/main/java/de/unistuttgart/informatik/fius/jvk/verifier/Sheet3Task2Verifier.java
@@ -113,6 +113,17 @@ public class Sheet3Task2Verifier implements TaskVerifier {
             this.taskG = this.taskG.updateStatus(TaskVerificationStatus.SUCCESSFUL);
         }
         
+        if (
+            (this.taskA.getTaskStatus().equals(TaskVerificationStatus.SUCCESSFUL))
+                    && (this.taskC.getTaskStatus().equals( TaskVerificationStatus.SUCCESSFUL))
+                    && (this.taskD.getTaskStatus().equals(TaskVerificationStatus.SUCCESSFUL))
+                    && (this.taskE.getTaskStatus().equals(TaskVerificationStatus.SUCCESSFUL))
+                    && (this.taskF.getTaskStatus().equals(TaskVerificationStatus.SUCCESSFUL))
+                    && (this.taskG.getTaskStatus().equals(TaskVerificationStatus.SUCCESSFUL))
+        ) {
+            this.taskH = this.taskH.updateStatus(TaskVerificationStatus.SUCCESSFUL);
+        }
+        
         List<BasicTaskInformation> subTasks = new ArrayList<>();
         subTasks.add(this.taskA);
         subTasks.add(this.taskC);

--- a/sheets/3/exercise-2.tex
+++ b/sheets/3/exercise-2.tex
@@ -82,7 +82,7 @@ while(true){
 
 	\item
 		Wenn sich Neo auf einem Feld mit genau einer Münze befindet, dann lass ihn sich nach rechts drehen und diese Münze aufsammeln. 
-		Wenn Neo die Münze aufgesammelt hat, soll er sich danach erstmal wieder nach vorne bewegen (auch wenn jetzt unter ihm keine Münze mehr liegt), bis er auf einem leeren Feld stehen bleibt (also wie in c) beschrieben).
+		Wenn Neo die Münze aufgesammelt hat, soll er sich danach wieder nach vorne bewegen (da jetzt unter ihm keine Münze mehr liegt), bis er auf einem leeren Feld stehen bleibt (also wie in c) beschrieben).
 
 
 	\item

--- a/sheets/3/exercise-2.tex
+++ b/sheets/3/exercise-2.tex
@@ -72,7 +72,7 @@ if (neo1.getPosition().equals(new Position(1, 1))){
 \begin{enumerate}\setcounter{enumi}{2}
 	\item
 		Lass Neo immer wenn sich keine Münze unter ihm befindet einen Schritt nach vorne gehen.
-		Tipp: Verwende hierfür am besten eine Endlosschleife und Schreibe deinen Code in den Schleifenkörper.
+		Tipp: Verwende hierfür am besten eine Endlosschleife und Schreibe den Code für alle Unteraufgaben dieser Aufgabe in den Schleifenkörper.
 		Eine Endlosschleife kann z.B. so aussehen:
 	\begin{lstlisting}
 while(true){

--- a/sheets/3/exercise-2.tex
+++ b/sheets/3/exercise-2.tex
@@ -71,10 +71,18 @@ if (neo1.getPosition().equals(new Position(1, 1))){
 
 \begin{enumerate}\setcounter{enumi}{2}
 	\item
-		Lasse Neo solange laufen bis sich mindestens eine Münze auf dem Feld unter ihm befindet.
+		Lass Neo immer wenn sich keine Münze unter ihm befindet einen Schritt nach vorne gehen.
+		Tipp: Verwende hierfür am besten eine Endlosschleife und Schreibe deinen Code in den Schleifenkörper.
+		Eine Endlosschleife kann z.B. so aussehen:
+	\begin{lstlisting}
+while(true){
+//your code here
+}
+	\end{lstlisting}
 
 	\item
-		Wenn sich Neo auf einem Feld mit genau einer Münze befindet, dann lass ihn sich nach rechts drehen und diese Münze aufsammeln.
+		Wenn sich Neo auf einem Feld mit genau einer Münze befindet, dann lass ihn sich nach rechts drehen und diese Münze aufsammeln. 
+		Wenn Neo die Münze aufgesammelt hat soll er sich danach wieder nach vorne bewegen bis, da er ja wieder auf einem leeren Feld steht (sich also wie in c) beschrieben).
 
 	\item
 		Wenn sich mehr als eine Münze unter Neo befindet, lass ihn sich auch nach rechts drehen und eine Münze aufsammeln.
@@ -130,6 +138,7 @@ if ( neo.canMove() || neo.getCurrentlyCollectableCoins().size()==7) ){
 
 	\item
 		Lasse Neo laufen bis er 10 Münzen gesammelt hat ODER 20 Schritte gegangen ist.
+		Tipp: Hierfür kannst du entweder das Argument der Endlosschleife ändern oder \lstinline{break} Verwenden
 
 		\begin{Infobox}[Break]
 			Wenn du eine Schleife inerhalb des Schleifendurchlaufs beenden willst bracuht du das Kommando \lstinline{break;}. 

--- a/sheets/3/exercise-2.tex
+++ b/sheets/3/exercise-2.tex
@@ -82,7 +82,8 @@ while(true){
 
 	\item
 		Wenn sich Neo auf einem Feld mit genau einer Münze befindet, dann lass ihn sich nach rechts drehen und diese Münze aufsammeln. 
-		Wenn Neo die Münze aufgesammelt hat soll er sich danach wieder nach vorne bewegen bis, da er ja wieder auf einem leeren Feld steht (sich also wie in c) beschrieben).
+		Wenn Neo die Münze aufgesammelt hat, soll er sich danach erstmal wieder nach vorne bewegen (auch wenn jetzt unter ihm keine Münze mehr liegt), bis er auf einem leeren Feld stehen bleibt (also wie in c) beschrieben).
+
 
 	\item
 		Wenn sich mehr als eine Münze unter Neo befindet, lass ihn sich auch nach rechts drehen und eine Münze aufsammeln.


### PR DESCRIPTION
Das Problem an dieser Aufgabe war, dass es sich bei der alten Formulierung in c) anhörte als sollte neo nur laufen bis er das erste mal auf ein Feld mit einer Münze kommt und dann aufhören, also auch nicht mehr weiterlaufen nachdem erdie Münze aufgehoben und sich gedreht hat (wie bei d)). Das sich Neo nach dem Aufheben der Münzen und dem drehen weiterbewegt ist wichtig damit er die Aufgabe weiterhin abläuft und die verschiedenen Subtask ausführt. Darum enthält c) jetzt einen Hinweiß auf eine Endlos-while Schleife in die man dann die If Bedingungen schreiben kann. Diese Entlosschleife kann dann bei g) alternativ zu `break` geändert werden. Außerdem hat sich die c) sehr nach while angehört und wir wollen hier if Aufgaben machen. d) Enthält nun einen Hinweiß das neo auch nach dem Aufheben weiter laufen soll.