### PR TITLE
fixed flickering

### DIFF
--- a/project/src/main/java/de/unistuttgart/informatik/fius/jvk/provided/Game.java
+++ b/project/src/main/java/de/unistuttgart/informatik/fius/jvk/provided/Game.java
@@ -65,7 +65,7 @@ public class Game {
     public Game(String windowTitle, Task task, TaskVerifier verifier) {
         final WindowBuilder wb = new WindowBuilder();
         wb.setTitle(windowTitle);
-        wb.setGraphicsSettings(false, true);
+        wb.setGraphicsSettings(true, true);
         wb.buildWindow();
         this.window = wb.getBuiltWindow();
         this.registerTextures(this.window);


### PR DESCRIPTION
many students had issues with extreme flickering while running the program. this was caused by double buffering being turned off. 