### PR TITLE
tries to fix pipeline for tex documents

### DIFF
--- a/.github/workflows/CompileTex.yml
+++ b/.github/workflows/CompileTex.yml
@@ -20,7 +20,7 @@ jobs:
             apk add make zip
             cd sheets ; make
             zip --junk-paths sheets */jvk-blatt*.pdf
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: github.ref == 'refs/heads/master'
         with:
           name: sheet-pdfs


### PR DESCRIPTION
There is currently a deprecated command in use. (https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)
I replaced it with the newest version